### PR TITLE
Implement sprint 2 models and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install pydantic sqlalchemy openai httpx beautifulsoup4 apscheduler pytest black ruff pydantic-settings pytest-cov
+      - run: ruff .
+      - run: black --check .
+      - run: pytest --cov=models --cov-fail-under=85

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SpiceflowNesting
+# SpiceflowNesting ![CI](https://github.com/example/spiceflownesting/actions/workflows/ci.yml/badge.svg)
 
 > 📑 **Planning Note:** The detailed roadmap (original MVP & new Codex track) now lives in [`docs/SPRINT_PLAN.md`](docs/SPRINT_PLAN.md). This README only carries the quick-start instructions.
 
@@ -27,4 +27,10 @@ cd <repo>
 cp .env.example .env  # add your keys
 poetry install
 poetry run python -m scheduler
+```
+
+### Database Migrations
+
+```bash
+poetry run alembic upgrade head
 ```

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,25 @@
+[alembic]
+script_location = migrations
+sqlalchemy.url = postgresql+psycopg://ai_bot:ai_bot@localhost:5432/ai_bot
+
+[loggers]
+keys = root
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from logging.config import fileConfig
+
+from sqlalchemy import create_engine
+from sqlalchemy import pool
+from alembic import context
+
+from models import Base
+from config import settings
+
+config = context.config
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+TARGET_METADATA = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=settings.DATABASE_URL, target_metadata=TARGET_METADATA, literal_binds=True
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = create_engine(settings.DATABASE_URL, poolclass=pool.NullPool)
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=TARGET_METADATA)
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/versions/001_create_tables.py
+++ b/migrations/versions/001_create_tables.py
@@ -1,0 +1,54 @@
+"""initial tables"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "sources",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("name", sa.String, nullable=False, unique=True),
+        sa.Column("url", sa.String, nullable=False),
+    )
+    op.create_table(
+        "listings",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("source_id", sa.Integer, sa.ForeignKey("sources.id")),
+        sa.Column("source_uid", sa.String, nullable=False),
+        sa.Column("url", sa.String, nullable=False),
+        sa.Column("title", sa.String),
+        sa.Column("price", sa.Integer),
+        sa.Column("beds", sa.Float),
+        sa.Column("baths", sa.Float),
+        sa.Column("sqft", sa.Integer),
+        sa.Column("lat", sa.Float),
+        sa.Column("lon", sa.Float),
+        sa.Column("amenities", sa.String),
+        sa.Column("first_seen", sa.DateTime, nullable=False),
+        sa.Column("last_seen", sa.DateTime, nullable=False),
+        sa.UniqueConstraint("source_id", "source_uid", name="uix_source_uid"),
+    )
+    op.create_table(
+        "scores",
+        sa.Column(
+            "listing_id", sa.Integer, sa.ForeignKey("listings.id"), primary_key=True
+        ),
+        sa.Column("score", sa.Float),
+        sa.Column("subscores", sa.String),
+        sa.Column("created_at", sa.DateTime, nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("scores")
+    op.drop_table("listings")
+    op.drop_table("sources")

--- a/models.py
+++ b/models.py
@@ -1,41 +1,56 @@
-from sqlalchemy import (
-    Column,
-    Integer,
-    String,
-    Float,
-    DateTime,
-    UniqueConstraint,
-    ForeignKey,
-)
-from sqlalchemy.orm import declarative_base
+"""Database models and base class definitions."""
+
+from __future__ import annotations
+
 import datetime as dt
 
-Base = declarative_base()
+from sqlalchemy import (
+    Column,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import DeclarativeBase
+
+__all__ = ["Source", "Listing", "Score", "Base"]
+
+
+class Base(DeclarativeBase):
+    """Base declarative class for all models."""
 
 
 class Source(Base):
+    """A site or API providing rental listings."""
+
     __tablename__ = "sources"
-    id = Column(Integer, primary_key=True)
-    name = Column(String, unique=True, nullable=False)
-    url = Column(String, nullable=False)
+
+    id: int = Column(Integer, primary_key=True)
+    name: str = Column(String, unique=True, nullable=False)
+    url: str = Column(String, nullable=False)
 
 
 class Listing(Base):
+    """A single rental listing scraped from a source."""
+
     __tablename__ = "listings"
-    id = Column(Integer, primary_key=True)
-    source_id = Column(Integer, ForeignKey("sources.id"))
-    source_uid = Column(String, nullable=False)
-    url = Column(String, nullable=False)
-    title = Column(String)
-    price = Column(Integer)
-    beds = Column(Float)
-    baths = Column(Float)
-    sqft = Column(Integer, nullable=True)
-    lat = Column(Float)
-    lon = Column(Float)
-    amenities = Column(String)
-    first_seen = Column(DateTime, default=dt.datetime.utcnow)
-    last_seen = Column(
+
+    id: int = Column(Integer, primary_key=True)
+    source_id: int = Column(Integer, ForeignKey("sources.id"))
+    source_uid: str = Column(String, nullable=False)
+    url: str = Column(String, nullable=False)
+    title: str | None = Column(String)
+    price: int | None = Column(Integer)
+    beds: float | None = Column(Float)
+    baths: float | None = Column(Float)
+    sqft: int | None = Column(Integer, nullable=True)
+    lat: float | None = Column(Float)
+    lon: float | None = Column(Float)
+    amenities: str | None = Column(String)
+    first_seen: dt.datetime = Column(DateTime, default=dt.datetime.utcnow)
+    last_seen: dt.datetime = Column(
         DateTime, default=dt.datetime.utcnow, onupdate=dt.datetime.utcnow
     )
     __table_args__ = (
@@ -44,8 +59,11 @@ class Listing(Base):
 
 
 class Score(Base):
+    """Aggregated score information for a Listing."""
+
     __tablename__ = "scores"
-    listing_id = Column(Integer, ForeignKey("listings.id"), primary_key=True)
-    score = Column(Float)
-    subscores = Column(String)
-    created_at = Column(DateTime, default=dt.datetime.utcnow)
+
+    listing_id: int = Column(Integer, ForeignKey("listings.id"), primary_key=True)
+    score: float | None = Column(Float)
+    subscores: str | None = Column(String)
+    created_at: dt.datetime = Column(DateTime, default=dt.datetime.utcnow)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,35 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from models import Base, Source, Listing, Score
+
+
+def setup_db():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return Session(bind=engine)
+
+
+def test_crud_and_constraints():
+    db = setup_db()
+    src = Source(name="zillow", url="https://zillow.com")
+    db.add(src)
+    db.commit()
+    lst = Listing(source_id=src.id, source_uid="1", url="url")
+    db.add(lst)
+    db.commit()
+
+    # unique constraint
+    dup = Listing(source_id=src.id, source_uid="1", url="u")
+    db.add(dup)
+    try:
+        db.commit()
+        raise AssertionError("unique constraint not enforced")
+    except Exception:
+        db.rollback()
+
+    sc = Score(listing_id=lst.id, score=50)
+    db.add(sc)
+    db.commit()
+    assert db.query(Score).count() == 1
+
+    db.close()


### PR DESCRIPTION
## Summary
- document models using type hints and docstrings
- add Alembic environment and initial migration
- bootstrap CI workflow with linting and tests
- add database instructions and CI badge to README
- test CRUD constraints for the models

## Testing
- `ruff check .`
- `black --check .`
- `pytest -k test_models --cov=models --cov-fail-under=85 -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b653829948327addbe512f0bd7b42