### PR TITLE
Implement geocoder utility and distance filter

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -7,6 +7,7 @@ from sqlalchemy import create_engine
 from models import Source, Listing
 from config import settings
 from scoring import refresh_scores
+from utils.geo import geocode_address
 
 engine = create_engine(settings.DATABASE_URL, future=True, echo=False)
 Session = sessionmaker(engine)
@@ -34,6 +35,10 @@ async def run_scraper(name, module_path, db):
     db.merge(source)
     db.flush()
     async for item in mod.fetch_raw():
+        if item.get("lat") is None or item.get("lon") is None:
+            loc = geocode_address(item.get("title", ""))
+            if loc:
+                item["lat"], item["lon"] = loc
         lst = Listing(source_id=source.id, **item)
         db.merge(lst)
     db.commit()

--- a/scoring.py
+++ b/scoring.py
@@ -35,6 +35,8 @@ def score_listing(listing: Listing, market_ppsf_25: float) -> dict:
         x in (listing.amenities or "") for x in ["dishwasher", "air", "laundry"]
     ):
         return {"passed": False}
+    if listing.lat is None or listing.lon is None:
+        return {"passed": False}
     if haversine_miles(listing.lat, listing.lon) > settings.MAX_DISTANCE_MILES:
         return {"passed": False}
 

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -1,11 +1,36 @@
 import sys
 from pathlib import Path
+from types import SimpleNamespace
+
+import httpx
+import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from utils.geo import haversine_miles
+from utils.geo import haversine_miles, geocode_address
 
 
 def test_haversine():
     # Distance from Liberty & Main to itself should be ~0
     assert haversine_miles(42.2808, -83.7480) < 0.01
+
+
+@pytest.fixture
+def one_mile_north():
+    return 42.2808 + 1 / 69, -83.7480
+
+
+def test_haversine_tolerance(one_mile_north):
+    d = haversine_miles(*one_mile_north)
+    assert abs(d - 1.0) < 0.031
+
+
+def test_geocode_address(monkeypatch):
+    def fake_get(*args, **kwargs):
+        return SimpleNamespace(
+            raise_for_status=lambda: None,
+            json=lambda: [{"lat": "42.0", "lon": "-83.0"}],
+        )
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+    assert geocode_address("addr") == (42.0, -83.0)

--- a/tests/test_scheduler_geo.py
+++ b/tests/test_scheduler_geo.py
@@ -1,0 +1,36 @@
+import os
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+
+import sys
+from pathlib import Path
+import types
+import asyncio
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from models import Base, Listing
+import scheduler
+
+
+def setup_db():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return Session(bind=engine)
+
+
+async def dummy_fetch_raw():
+    yield {"source_uid": "1", "url": "u", "title": "addr"}
+
+
+def test_scheduler_geo(monkeypatch):
+    db = setup_db()
+    mod = types.SimpleNamespace(fetch_raw=dummy_fetch_raw)
+    monkeypatch.setattr(scheduler, "import_module", lambda _: mod)
+    monkeypatch.setattr(scheduler, "geocode_address", lambda addr: (1.0, 2.0))
+    asyncio.run(scheduler.run_scraper("dummy", "dummy", db))
+    lst = db.query(Listing).first()
+    assert (lst.lat, lst.lon) == (1.0, 2.0)

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import json
+
+import scoring
+from scoring import score_listing
+
+
+class DummyListing:
+    def __init__(self, lat, lon):
+        self.lat = lat
+        self.lon = lon
+        self.beds = 1
+        self.baths = 1
+        self.sqft = 500
+        self.price = 1000
+        self.amenities = json.dumps(["dishwasher", "air", "laundry"])
+        self.title = "test"
+
+
+def test_distance_filter(monkeypatch):
+    monkeypatch.setattr(scoring, "_sentiment", lambda text: 0.5)
+    close = DummyListing(42.2808, -83.7480)
+    far = DummyListing(42.31, -83.7480)
+    assert score_listing(close, 1)["passed"]
+    assert not score_listing(far, 1)["passed"]

--- a/utils/geo.py
+++ b/utils/geo.py
@@ -1,4 +1,10 @@
+"""Geospatial helpers."""
+
 from math import radians, cos, sin, asin, sqrt
+from typing import Optional, Tuple
+
+import httpx
+
 from config import settings
 
 
@@ -9,3 +15,18 @@ def haversine_miles(lat1, lon1, lat2=settings.DOWNTOWN_LAT, lon2=settings.DOWNTO
     a = sin(dlat / 2) ** 2 + cos(lat1) * cos(lat2) * sin(dlon / 2) ** 2
     miles = 3958.8 * 2 * asin(sqrt(a))
     return miles
+
+
+def geocode_address(address: str) -> Optional[Tuple[float, float]]:
+    """Return latitude and longitude for an address using Nominatim."""
+
+    url = "https://nominatim.openstreetmap.org/search"
+    params = {"q": address, "format": "json", "limit": 1}
+    r = httpx.get(
+        url, params=params, headers={"User-Agent": "spiceflownesting"}, timeout=10
+    )
+    r.raise_for_status()
+    data = r.json()
+    if not data:
+        return None
+    return float(data[0]["lat"]), float(data[0]["lon"])


### PR DESCRIPTION
## Summary
- add `geocode_address` helper using Nominatim
- skip distance scoring when coordinates are missing or >1 mile
- enrich scheduler with geocoding for missing coordinates
- test geocoder, scoring distance filter, and scheduler geocoding

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b6b8a573083279be73a9e4a440fed