### PR TITLE
feat(s05): implement craigslist scraper

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -14,6 +14,7 @@ Session = sessionmaker(engine)
 
 SCRAPERS = {
     "zillow": "scrapers.zillow",
+    "craigslist": "scrapers.craigslist",
 }
 
 

--- a/scrapers/craigslist.py
+++ b/scrapers/craigslist.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+import json
+from bs4 import BeautifulSoup
+import httpx
+
+BASE = "https://annarbor.craigslist.org"
+SEARCH_PATH = "/search/apa"
+
+
+async def fetch_raw():
+    url = f"{BASE}{SEARCH_PATH}"
+    async with httpx.AsyncClient(timeout=15) as client:
+        r = await client.get(url, headers={"User-Agent": "Mozilla/5.0"})
+    soup = BeautifulSoup(r.text, "html.parser")
+    items = soup.select("ol.cl-static-search-results li.cl-static-search-result")
+    meta = json.loads(soup.find("script", id="ld_searchpage_results").string)[
+        "itemListElement"
+    ]
+    for li, js in zip(items, meta):
+        title = li.find("div", class_="title").get_text(strip=True)
+        href = li.find("a")["href"]
+        price_el = li.find("div", class_="price")
+        price = (
+            int(price_el.get_text(strip=True).strip("$").replace(",", ""))
+            if price_el
+            else None
+        )
+        yield {
+            "source_uid": js.get("position"),
+            "url": href,
+            "title": title,
+            "price": price,
+            "beds": js["item"].get("numberOfBedrooms"),
+            "baths": js["item"].get("numberOfBathroomsTotal"),
+            "sqft": None,
+            "lat": js["item"].get("latitude"),
+            "lon": js["item"].get("longitude"),
+            "amenities": "[]",
+        }

--- a/tests/data/craig_sample.html
+++ b/tests/data/craig_sample.html
@@ -1,0 +1,92 @@
+<html><body><script id="ld_searchpage_results" type="application/ld+json">{"itemListElement": [{"item": {"address": {"postalCode": "", "addressLocality": "Ypsilanti", "addressRegion": "MI", "streetAddress": "", "@type": "PostalAddress", "addressCountry": ""}, "@context": "http://schema.org", "numberOfBedrooms": 2, "longitude": -83.6335968272774, "@type": "Apartment", "numberOfBathroomsTotal": 1, "name": "2/BD, Controlled Access, High Speed Internet Ready", "latitude": 42.2325007799011}, "@type": "ListItem", "position": "0"}, {"item": {"latitude": 42.2780784265857, "name": "UofM Central Campus - 1 bedroom apt., 2 blocks from DIAG", "numberOfBathroomsTotal": 1, "address": {"addressCountry": "", "addressLocality": "Ann Arbor", "addressRegion": "MI", "streetAddress": "", "@type": "PostalAddress", "postalCode": ""}, "@context": "http://schema.org", "numberOfBedrooms": 1, "longitude": -83.7436104535145, "@type": "Apartment"}, "position": "1", "@type": "ListItem"}, {"position": "2", "@type": "ListItem", "item": {"name": "12-24 N HURON 2-3 BEDROOM APT AVAILABLE AUGUST 1 2025", "latitude": 42.2411856741592, "address": {"addressCountry": "", "addressRegion": "MI", "addressLocality": "Ypsilanti", "@type": "PostalAddress", "streetAddress": "", "postalCode": ""}, "@context": "http://schema.org", "numberOfBedrooms": 3, "@type": "Apartment", "longitude": -83.6128127832602, "numberOfBathroomsTotal": 1}}, {"item": {"address": {"postalCode": "", "@type": "PostalAddress", "streetAddress": "", "addressRegion": "MI", "addressLocality": "Ypsilanti", "addressCountry": ""}, "@context": "http://schema.org", "numberOfBedrooms": 2, "longitude": -83.6335968272774, "@type": "Apartment", "numberOfBathroomsTotal": 1, "name": "2 Bed, Ceiling Fans, Laundry Facility", "latitude": 42.2325007799011}, "position": "3", "@type": "ListItem"}, {"item": {"latitude": 42.2648350801097, "name": "House", "numberOfBathroomsTotal": 2, "address": {"postalCode": "", "addressCountry": "", "addressLocality": "Ann Arbor", "addressRegion": "MI", "@type": "PostalAddress", "streetAddress": ""}, "@context": "http://schema.org", "numberOfBedrooms": 3, "@type": "House", "longitude": -83.7183733815138}, "@type": "ListItem", "position": "4"}, {"position": "5", "@type": "ListItem", "item": {"name": "Quiet and spacious townhouse in Howell", "latitude": 42.6242257218752, "address": {"postalCode": "", "addressCountry": "", "addressRegion": "MI", "addressLocality": "Howell", "streetAddress": "", "@type": "PostalAddress"}, "@context": "http://schema.org", "numberOfBedrooms": 2, "@type": "House", "longitude": -83.9573964767268, "numberOfBathroomsTotal": 2}}, {"item": {"numberOfBathroomsTotal": 1, "longitude": -83.6335968272774, "@type": "Apartment", "numberOfBedrooms": 1, "address": {"streetAddress": "", "@type": "PostalAddress", "addressRegion": "MI", "addressLocality": "Ypsilanti", "addressCountry": "", "postalCode": ""}, "@context": "http://schema.org", "latitude": 42.2325007799011, "name": "1/bd 1/ba, Oversized Closets, On Public Transportation Line"}, "position": "6", "@type": "ListItem"}, {"position": "7", "@type": "ListItem", "item": {"latitude": 42.2839987994824, "name": "Wonderful 3 bedroom/1 bath in Wines School neighborhood", "numberOfBathroomsTotal": 1, "@type": "Apartment", "longitude": -83.7460014063935, "numberOfBedrooms": 3, "@context": "http://schema.org", "address": {"postalCode": "", "addressCountry": "", "streetAddress": "", "@type": "PostalAddress", "addressRegion": "MI", "addressLocality": "Ann Arbor"}}}, {"position": "8", "@type": "ListItem", "item": {"numberOfBathroomsTotal": 1, "@type": "Apartment", "longitude": -83.6335968272774, "address": {"postalCode": "", "addressCountry": "", "@type": "PostalAddress", "streetAddress": "", "addressRegion": "MI", "addressLocality": "Ypsilanti"}, "@context": "http://schema.org", "numberOfBedrooms": 2, "latitude": 42.2325007799011, "name": "2 Bed, Oversized Closets, Situated in Ypsilanti!"}}, {"item": {"longitude": -83.6900686934781, "@type": "Apartment", "address": {"postalCode": "", "addressCountry": "", "addressRegion": "MI", "addressLocality": "Milan", "streetAddress": "", "@type": "PostalAddress"}, "@context": "http://schema.org", "numberOfBedrooms": 2, "numberOfBathroomsTotal": 1, "name": "Spacious Apartment For Rent", "latitude": 42.0774658489984}, "@type": "ListItem", "position": "9"}]}</script><ol class="cl-static-search-results"><li class="cl-static-search-result" title="2/BD, Controlled Access, High Speed Internet Ready">
+<a href="https://annarbor.craigslist.org/apa/d/ypsilanti-bd-controlled-access-high/7855134489.html">
+<div class="title">2/BD, Controlled Access, High Speed Internet Ready</div>
+<div class="details">
+<div class="price">$1,149</div>
+<div class="location">
+                        212 Stevens Drive, Ypsilanti, MI
+                    </div>
+</div>
+</a>
+</li><li class="cl-static-search-result" title="UofM Central Campus - 1 bedroom apt., 2 blocks from DIAG">
+<a href="https://annarbor.craigslist.org/apa/d/ann-arbor-uofm-central-campus-bedroom/7856970660.html">
+<div class="title">UofM Central Campus - 1 bedroom apt., 2 blocks from DIAG</div>
+<div class="details">
+<div class="price">$1,445</div>
+<div class="location">
+                        Ann Arbor
+                    </div>
+</div>
+</a>
+</li><li class="cl-static-search-result" title="12-24 N HURON 2-3 BEDROOM APT AVAILABLE AUGUST 1 2025">
+<a href="https://annarbor.craigslist.org/apa/d/ypsilanti-huron-3-bedroom-apt-available/7857742839.html">
+<div class="title">12-24 N HURON 2-3 BEDROOM APT AVAILABLE AUGUST 1 2025</div>
+<div class="details">
+<div class="price">$1,400</div>
+</div>
+</a>
+</li><li class="cl-static-search-result" title="2 Bed, Ceiling Fans, Laundry Facility">
+<a href="https://annarbor.craigslist.org/apa/d/ypsilanti-bed-ceiling-fans-laundry/7855636498.html">
+<div class="title">2 Bed, Ceiling Fans, Laundry Facility</div>
+<div class="details">
+<div class="price">$1,149</div>
+<div class="location">
+                        212 Stevens Drive, Ypsilanti, MI
+                    </div>
+</div>
+</a>
+</li><li class="cl-static-search-result" title="House">
+<a href="https://annarbor.craigslist.org/apa/d/ann-arbor-house/7857741704.html">
+<div class="title">House</div>
+<div class="details">
+<div class="price">$3,000</div>
+</div>
+</a>
+</li><li class="cl-static-search-result" title="Quiet and spacious townhouse in Howell">
+<a href="https://annarbor.craigslist.org/apa/d/howell-quiet-and-spacious-townhouse-in/7857739293.html">
+<div class="title">Quiet and spacious townhouse in Howell</div>
+<div class="details">
+<div class="price">$1,750</div>
+</div>
+</a>
+</li><li class="cl-static-search-result" title="1/bd 1/ba, Oversized Closets, On Public Transportation Line">
+<a href="https://annarbor.craigslist.org/apa/d/ypsilanti-bd-ba-oversized-closets-on/7853314206.html">
+<div class="title">1/bd 1/ba, Oversized Closets, On Public Transportation Line</div>
+<div class="details">
+<div class="price">$1,009</div>
+<div class="location">
+                        212 Stevens Drive, Ypsilanti, MI
+                    </div>
+</div>
+</a>
+</li><li class="cl-static-search-result" title="Wonderful 3 bedroom/1 bath in Wines School neighborhood">
+<a href="https://annarbor.craigslist.org/apa/d/ann-arbor-wonderful-bedroom-bath-in/7857700190.html">
+<div class="title">Wonderful 3 bedroom/1 bath in Wines School neighborhood</div>
+<div class="details">
+<div class="price">$1,250</div>
+<div class="location">
+                        Ann Arbor
+                    </div>
+</div>
+</a>
+</li><li class="cl-static-search-result" title="2 Bed, Oversized Closets, Situated in Ypsilanti!">
+<a href="https://annarbor.craigslist.org/apa/d/ypsilanti-bed-oversized-closets/7856611429.html">
+<div class="title">2 Bed, Oversized Closets, Situated in Ypsilanti!</div>
+<div class="details">
+<div class="price">$1,149</div>
+<div class="location">
+                        212 Stevens Drive, Ypsilanti, MI
+                    </div>
+</div>
+</a>
+</li><li class="cl-static-search-result" title="Spacious Apartment For Rent">
+<a href="https://annarbor.craigslist.org/apa/d/milan-spacious-apartment-for-rent/7857691986.html">
+<div class="title">Spacious Apartment For Rent</div>
+<div class="details">
+<div class="price">$1,320</div>
+<div class="location">
+                        Milan, MI
+                    </div>
+</div>
+</a>
+</li></ol></body></html>

--- a/tests/test_craigslist.py
+++ b/tests/test_craigslist.py
@@ -1,0 +1,35 @@
+import sys
+from pathlib import Path
+import asyncio
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import scrapers.craigslist as craigslist
+
+
+class FakeAsyncClient:
+    def __init__(self, text):
+        self.text = text
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def get(self, *_, **__):
+        class R:
+            def __init__(self, text):
+                self.text = text
+        return R(self.text)
+
+
+@pytest.mark.asyncio
+async def test_craigslist_parse(monkeypatch):
+    html = Path(__file__).with_name('data').joinpath('craig_sample.html').read_text()
+    monkeypatch.setattr(craigslist.httpx, 'AsyncClient', lambda *a, **k: FakeAsyncClient(html))
+    listings = [item async for item in craigslist.fetch_raw()]
+    assert len(listings) >= 10
+    assert all('title' in l for l in listings)

--- a/tests/test_integration_scrapers.py
+++ b/tests/test_integration_scrapers.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import scrapers.zillow as zillow
+import scrapers.craigslist as craigslist
+
+
+@pytest.mark.live
+@pytest.mark.asyncio
+async def test_zillow_live():
+    try:
+        listings = [item async for item in zillow.fetch_raw()]
+    except Exception as e:
+        pytest.skip(f"zillow fetch failed: {e}")
+    if len(listings) < 10:
+        pytest.skip("zillow returned too few listings")
+    assert all("url" in lst for lst in listings)
+
+
+@pytest.mark.live
+@pytest.mark.asyncio
+async def test_craigslist_live():
+    try:
+        listings = [item async for item in craigslist.fetch_raw()]
+    except Exception as e:
+        pytest.skip(f"craigslist fetch failed: {e}")
+    if len(listings) < 10:
+        pytest.skip("craigslist returned too few listings")
+    assert all('url' in lst for lst in listings)


### PR DESCRIPTION
## Summary
- implement craigslist scraper
- register zillow and craigslist scrapers in scheduler
- add integration tests for live scraping
- add mocked unit test for craigslist scraper
- include sample craigslist HTML for mocking

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b7d001e048327a962f276a1afc9ac