### PR TITLE
feat(s06): scheduler run logging and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ git clone <repo>
 cd <repo>
 cp .env.example .env  # add your keys
 poetry install
-poetry run python -m scheduler
+poetry run rentbot run-once  # single cycle
 ```
 
 ### Database Migrations

--- a/migrations/versions/8c5ef4639df1_add_run_table.py
+++ b/migrations/versions/8c5ef4639df1_add_run_table.py
@@ -1,0 +1,22 @@
+"""add run table"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "8c5ef4639df1"
+down_revision = "72356bc9b2a0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "runs",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("started_at", sa.DateTime, nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("runs")

--- a/models.py
+++ b/models.py
@@ -15,7 +15,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import DeclarativeBase
 
-__all__ = ["Source", "Listing", "Score", "Base"]
+__all__ = ["Source", "Listing", "Score", "Run", "Base"]
 
 
 class Base(DeclarativeBase):
@@ -67,3 +67,12 @@ class Score(Base):
     score: float | None = Column(Float)
     subscores: str | None = Column(String)
     created_at: dt.datetime = Column(DateTime, default=dt.datetime.utcnow)
+
+
+class Run(Base):
+    """Log of scheduler runs."""
+
+    __tablename__ = "runs"
+
+    id: int = Column(Integer, primary_key=True)
+    started_at: dt.datetime = Column(DateTime, default=dt.datetime.utcnow)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ line-length = 88
 [tool.pytest.ini_options]
 addopts = "-ra"
 
+[project.scripts]
+rentbot = "scheduler:cli"
+
 [tool.poetry.dev-dependencies]
 pytest = "*"
 black = "*"

--- a/scheduler.py
+++ b/scheduler.py
@@ -1,10 +1,13 @@
 import asyncio
 import logging
 from datetime import datetime
+import argparse
 from importlib import import_module
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy import create_engine
-from models import Source, Listing
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.interval import IntervalTrigger
+from models import Source, Listing, Run
 from config import settings
 from scoring import refresh_scores
 from utils.geo import geocode_address
@@ -20,6 +23,8 @@ SCRAPERS = {
 
 async def run_once():
     db = Session()
+    db.add(Run())
+    db.commit()
     await asyncio.gather(
         *(run_scraper(name, mod, db) for name, mod in SCRAPERS.items())
     )
@@ -30,24 +35,49 @@ async def run_once():
 async def run_scraper(name, module_path, db):
     logging.info("Running %s at %s", name, datetime.utcnow())
     mod = import_module(module_path)
-    source = db.query(Source).filter_by(name=name).first() or Source(
-        name=name, url=module_path
-    )
-    db.merge(source)
+    existing = db.query(Source).filter_by(name=name).first()
+    source = existing or Source(name=name, url=module_path)
+    source = db.merge(source)
     db.flush()
     async for item in mod.fetch_raw():
         if item.get("lat") is None or item.get("lon") is None:
             coords = await geocode_address(item.get("title", ""))
             if coords:
                 item["lat"], item["lon"] = coords
-        lst = Listing(source_id=source.id, **item)
-        db.merge(lst)
+        existing = (
+            db.query(Listing)
+            .filter_by(source_id=source.id, source_uid=item["source_uid"])
+            .first()
+        )
+        if existing:
+            for k, v in item.items():
+                setattr(existing, k, v)
+        else:
+            db.add(Listing(source_id=source.id, **item))
     db.commit()
 
 
+def start_scheduler():
+    sched = AsyncIOScheduler()
+    sched.add_job(
+        run_once,
+        IntervalTrigger(hours=settings.RUN_INTERVAL_HOURS),
+        max_instances=1,
+    )
+    sched.start()
+    asyncio.get_event_loop().run_forever()
+
+
+def cli(argv=None):
+    parser = argparse.ArgumentParser(prog="rentbot")
+    parser.add_argument("command", choices=["run-once"])
+    args = parser.parse_args(argv)
+    if args.command == "run-once":
+        asyncio.run(run_once())
+
+
 def main():
-    scheduler = asyncio.get_event_loop()
-    scheduler.run_until_complete(run_once())
+    start_scheduler()
 
 
 if __name__ == "__main__":

--- a/tests/test_scheduler_cli.py
+++ b/tests/test_scheduler_cli.py
@@ -1,0 +1,12 @@
+import scheduler
+
+
+def test_cli_exit(monkeypatch):
+    called = {}
+
+    async def fake_run_once():
+        called["x"] = True
+
+    monkeypatch.setattr(scheduler, "run_once", fake_run_once)
+    scheduler.cli(["run-once"])
+    assert called.get("x")

--- a/tests/test_scheduler_dedupe.py
+++ b/tests/test_scheduler_dedupe.py
@@ -1,0 +1,39 @@
+import asyncio
+import types
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+import scheduler
+from models import Base, Listing, Run
+
+
+async def fake_fetch_raw():
+    yield {
+        "source_uid": "1",
+        "url": "u",
+        "title": "t",
+        "beds": 1,
+        "baths": 1,
+        "amenities": "[]",
+    }
+
+
+def test_dedupe(monkeypatch):
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(engine)
+    monkeypatch.setattr(scheduler, "Session", Session)
+    mod = types.ModuleType("m")
+    mod.fetch_raw = fake_fetch_raw
+    monkeypatch.setattr(scheduler, "import_module", lambda *_: mod)
+    monkeypatch.setattr(scheduler, "SCRAPERS", {"fake": "m"})
+
+    async def g(*_):
+        return 1.0, 2.0
+
+    monkeypatch.setattr(scheduler, "geocode_address", g)
+    asyncio.run(scheduler.run_once())
+    asyncio.run(scheduler.run_once())
+    db = Session()
+    assert db.query(Listing).count() == 1
+    assert db.query(Run).count() == 2


### PR DESCRIPTION
## Summary
- log scraping runs in new table
- schedule jobs via `RUN_INTERVAL_HOURS`
- add `rentbot run-once` CLI
- document CLI usage in README
- tests for CLI and dedupe

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b7f2291bc8327b95164282fec29e1