### PR TITLE
feat(s08): scoring weights and percentile

### DIFF
--- a/scoring.py
+++ b/scoring.py
@@ -2,50 +2,60 @@ import json
 import statistics
 from openai import OpenAI
 from sqlalchemy.orm import Session
+from scrapers.url_helpers import load_criteria
 from models import Listing, Score
 from config import settings
 from utils.geo import haversine_miles
 
 client = OpenAI(api_key=settings.OPENAI_API_KEY)
+CRITERIA = load_criteria()
 
 
 def _sentiment(text: str) -> float:
-    resp = client.chat.completions.create(
-        model="gpt-4o-mini",
-        messages=[
-            {
-                "role": "system",
-                "content": "Score 0-1 how luxurious and pleasant this rental sounds.",
-            },
-            {"role": "user", "content": text[:4000]},
-        ],
-        max_tokens=1,
-        logprobs=True,
-    )
+    """Return sentiment score 0-1 via OpenAI; fallback to neutral on error."""
     try:
+        resp = client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[
+                {
+                    "role": "system",
+                    "content": "Score 0-1 how luxurious and pleasant this rental sounds.",
+                },
+                {"role": "user", "content": text[:4000]},
+            ],
+            max_tokens=1,
+            logprobs=True,
+        )
         return float(resp.choices[0].message.content.strip())
     except Exception:
         return 0.5
 
 
 def score_listing(listing: Listing, market_ppsf_25: float) -> dict:
-    if listing.beds < 1 or listing.baths < 1:
+    """Return weighted subscores; ensure listing meets YAML criteria."""
+    if CRITERIA.get("min_beds") and (listing.beds or 0) < CRITERIA["min_beds"]:
         return {"passed": False}
-    if not all(
-        x in (listing.amenities or "") for x in ["dishwasher", "air", "laundry"]
+    if (
+        CRITERIA.get("max_rent")
+        and listing.price
+        and listing.price > CRITERIA["max_rent"]
     ):
+        return {"passed": False}
+    req = CRITERIA.get("required_amenities") or []
+    if not all(x in (listing.amenities or "") for x in req):
         return {"passed": False}
     if listing.lat is None or listing.lon is None:
         return {"passed": False}
-    if haversine_miles(listing.lat, listing.lon) > settings.MAX_DISTANCE_MILES:
+    radius = CRITERIA.get("radius_miles", settings.MAX_DISTANCE_MILES)
+    if haversine_miles(listing.lat, listing.lon) > radius:
         return {"passed": False}
 
     subs = {}
-    ppsf = listing.price / listing.sqft if listing.sqft else listing.price
-    subs["price"] = max(0, min(40, 40 * (market_ppsf_25 / ppsf)))
-    subs["amenities"] = min(25, 3 * len(json.loads(listing.amenities)))
+    ppsf = (listing.price or 0) / (listing.sqft or 1)
+    subs["price"] = max(0, min(40, 40 * (market_ppsf_25 / max(ppsf, 1))))
+    subs["amenities"] = min(25, 3 * len(json.loads(listing.amenities or "[]")))
     subs["distance"] = 10 if haversine_miles(listing.lat, listing.lon) < 0.5 else 5
-    subs["sentiment"] = 25 * _sentiment(listing.title)
+    subs["sentiment"] = 25 * _sentiment(listing.title or "")
 
     total = round(sum(subs.values()), 1)
     subs["total"] = total
@@ -53,12 +63,19 @@ def score_listing(listing: Listing, market_ppsf_25: float) -> dict:
     return subs
 
 
-def refresh_scores(db: Session):
+def get_market_ppsf_percentile(db: Session, pct: float = 0.25) -> float:
+    """Return price-per-sqft percentile for current listings."""
     prices = [
         item.price / (item.sqft or 1)
         for item in db.query(Listing).filter(Listing.sqft.isnot(None))
     ]
-    p25 = statistics.quantiles(prices, n=4)[0] if prices else 1
+    if not prices:
+        return 1.0
+    return statistics.quantiles(prices, n=4)[0]
+
+
+def refresh_scores(db: Session):
+    p25 = get_market_ppsf_percentile(db)
     for lst in db.query(Listing):
         res = score_listing(lst, p25)
         if res.get("passed"):

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,55 @@
+import sys
+from pathlib import Path
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from models import Base, Listing
+import scoring
+
+
+def setup_db():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return Session(bind=engine)
+
+
+def test_percentile_calc():
+    db = setup_db()
+    for i, p in enumerate([1000, 2000, 3000, 4000], 1):
+        db.add(Listing(source_id=1, source_uid=str(i), url="u", price=p, sqft=100))
+    db.commit()
+    val = scoring.get_market_ppsf_percentile(db)
+    assert abs(val - 12.5) < 0.01
+
+
+def test_score_listing(monkeypatch):
+    monkeypatch.setattr(scoring, "_sentiment", lambda *_: 0.4)
+    monkeypatch.setattr(
+        scoring,
+        "CRITERIA",
+        {
+            "max_rent": 1500,
+            "min_beds": 1,
+            "radius_miles": 1.0,
+            "required_amenities": ["dishwasher"],
+        },
+    )
+    lst = Listing(
+        source_id=1,
+        source_uid="1",
+        url="u",
+        title="nice",
+        price=1000,
+        beds=1,
+        baths=1,
+        sqft=400,
+        lat=42.2808,
+        lon=-83.7480,
+        amenities='["dishwasher"]',
+    )
+    res = scoring.score_listing(lst, 10)
+    assert res["passed"]
+    assert 0 <= res["total"] <= 100
+    assert res["price"] == 40


### PR DESCRIPTION
## Summary
- tune `score_listing` to read YAML criteria
- compute nightly 25th percentile via `get_market_ppsf_percentile`
- guard OpenAI calls with fallback sentiment
- add unit tests for percentile and scoring

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b88de5bf8832798b385c15e52e287