### PR TITLE
feat(s10): feedback API and observability

### DIFF
--- a/feedback.py
+++ b/feedback.py
@@ -1,0 +1,33 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from loguru import logger
+from prometheus_client import Counter
+
+from config import settings
+from models import Score
+
+app = FastAPI()
+engine = create_engine(settings.DATABASE_URL, future=True, echo=False)
+Session = sessionmaker(engine)
+
+FEEDBACK_COUNTER = Counter("feedback_total", "User feedback events")
+
+
+class Feedback(BaseModel):
+    listing_id: int
+    feedback: int
+
+
+@app.post("/feedback")
+def submit_feedback(item: Feedback):
+    db = Session()
+    db.query(Score).filter_by(listing_id=item.listing_id).update(
+        {"feedback": item.feedback}
+    )
+    db.commit()
+    db.close()
+    FEEDBACK_COUNTER.inc()
+    logger.info("Feedback %s for listing %s", item.feedback, item.listing_id)
+    return {"status": "ok"}

--- a/migrations/versions/9fbc317abdfe_add_feedback_column.py
+++ b/migrations/versions/9fbc317abdfe_add_feedback_column.py
@@ -1,0 +1,19 @@
+"""add feedback column"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "9fbc317abdfe"
+down_revision = "8c5ef4639df1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("scores", sa.Column("feedback", sa.Integer()))
+
+
+def downgrade() -> None:
+    op.drop_column("scores", "feedback")

--- a/models.py
+++ b/models.py
@@ -66,6 +66,7 @@ class Score(Base):
     listing_id: int = Column(Integer, ForeignKey("listings.id"), primary_key=True)
     score: float | None = Column(Float)
     subscores: str | None = Column(String)
+    feedback: int | None = Column(Integer)
     created_at: dt.datetime = Column(DateTime, default=dt.datetime.utcnow)
 
 

--- a/notifier.py
+++ b/notifier.py
@@ -1,12 +1,16 @@
 from pathlib import Path
 from datetime import date
 import httpx
+from loguru import logger
+from prometheus_client import Counter
 from config import settings
 
 TEMPLATE = Path(__file__).parent / "templates" / "digest.html"
 
 # Repository root used for storing digest snapshots
 REPO_ROOT = Path(__file__).resolve().parent
+
+EMAIL_COUNTER = Counter("emails_sent_total", "Digest emails sent")
 
 
 def _save_snapshot(html: str) -> None:
@@ -49,3 +53,5 @@ async def send_digest(listings):
         )
         resp.raise_for_status()
     _save_snapshot(html)
+    EMAIL_COUNTER.inc()
+    logger.info("Digest sent with %d listings", len(listings))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,10 @@ dependencies = [
     "httpx>=0.25",
     "beautifulsoup4>=4.12",
     "apscheduler>=3.10",
+    "fastapi",
+    "uvicorn",
+    "loguru",
+    "prometheus_client",
 ]
 
 

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -1,0 +1,31 @@
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+import feedback
+from models import Base, Score
+
+
+def setup_app(monkeypatch):
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(engine)
+    monkeypatch.setattr(feedback, "Session", Session)
+    return TestClient(feedback.app), Session
+
+
+def test_feedback_updates_score(monkeypatch):
+    client, Session = setup_app(monkeypatch)
+    db = Session()
+    db.add(Score(listing_id=1, score=50))
+    db.commit()
+    db.close()
+    resp = client.post("/feedback", json={"listing_id": 1, "feedback": 1})
+    assert resp.status_code == 200
+    db = Session()
+    row = db.query(Score).filter_by(listing_id=1).first()
+    assert row.feedback == 1

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,31 @@
+import asyncio
+from types import SimpleNamespace
+from loguru import logger
+import notifier
+
+
+class FakeClient:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def post(self, *args, **kwargs):
+        class R:
+            def raise_for_status(self):
+                pass
+
+        return R()
+
+
+def test_log_line(monkeypatch):
+    out = []
+    logger.add(out.append, format="{message}")
+    monkeypatch.setattr(notifier.httpx, "AsyncClient", lambda *a, **k: FakeClient())
+    monkeypatch.setattr(notifier.settings, "SENDGRID_API_KEY", "x")
+    monkeypatch.setattr(notifier.settings, "SENDGRID_TO", "t@example.com")
+    monkeypatch.setattr(notifier.settings, "SENDGRID_FROM", "noreply@example.com")
+    listing = SimpleNamespace(url="u", title="t", price=1)
+    asyncio.run(notifier.send_digest([listing]))
+    assert any("Digest sent" in m for m in out)


### PR DESCRIPTION
## Summary
- add `feedback` column on `scores`
- expose `/feedback` FastAPI endpoint
- integrate Loguru and Prometheus counters
- capture email snapshots in docs
- tests for feedback endpoint and logging

## Testing
- `ruff check tests/test_feedback.py tests/test_logging.py feedback.py notifier.py scheduler.py models.py migrations/versions/9fbc317abdfe_add_feedback_column.py --fix`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b9189f2fc8327b9f99154d8066ffb